### PR TITLE
sqsh-ls: add --utc flag

### DIFF
--- a/test/tools/ls/utc.sh
+++ b/test/tools/ls/utc.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -ex
+
+######################################################################
+# @author      : Enno Boland (mail@eboland.de)
+# @file        : utc.sh
+# @created     : Monday Nov 20, 2023 18:24:05 CET
+
+#
+# @description : This script creates a squashfs image, mounts it, and
+#                repacks it from the mounted path.
+######################################################################
+
+: "${BUILD_DIR:?BUILD_DIR is not set}"
+: "${MKSQUASHFS:?MKSQUASHFS is not set}"
+: "${SOURCE_ROOT:?SOURCE_ROOT is not set}"
+: "${SQSH_LS:?SQSH_UNPACK is not set}"
+
+MKSQUASHFS_OPTS="-no-xattrs -noappend -all-root -mkfs-time 0"
+
+WORK_DIR="$BUILD_DIR/unpack-repack"
+
+mkdir -p "$WORK_DIR"
+cd "$WORK_DIR"
+
+mkdir -p "$PWD/empty"
+
+for i in $(seq 1 3641); do
+  echo "dir$i d 777 0 0";
+  echo "dir$i/file c 776 0 0 100 1";
+done
+
+# shellcheck disable=SC2086
+$MKSQUASHFS "$PWD/empty" "$PWD/large_tree.squashfs" -pf "$PWD/large_tree.pseudo" \
+	$MKSQUASHFS_OPTS
+$SQSH_LS -r -l --utc "$PWD/large_tree.squashfs"
+$SQSH_LS -r "$PWD/large_tree.squashfs"

--- a/test/tools/meson.build
+++ b/test/tools/meson.build
@@ -6,6 +6,7 @@ sqsh_extended_test = [
     'unpack/repack.sh',
     'unpack/pathtraversal/pathtraversal.sh',
     'ls/large-tree.sh',
+    'ls/utc.sh',
 ]
 sqsh_extended_fs_test = [
     'fs/large-file.sh',

--- a/tools/man/sqsh-ls.1.in
+++ b/tools/man/sqsh-ls.1.in
@@ -38,6 +38,10 @@ Print a long format listing of files and directories, similar to the
 output of the \fBls -l\fR command.
 
 .TP
+.BR \-u ", " \fB\-\-utc
+When running with \fB-l\fR use UTC timestamps instead of local time.
+
+.TP
 .BR \-v ", " \fB\-\-version
 Print the version of \fBsqsh-ls\fR and exit.
 


### PR DESCRIPTION
This change adds a `--utc` flag to `sqsh-ls`. This allows to ignore the local timezone and returns the mtime in UTC instead of local time.

This change was added to avoid the performance impact of calling localtime() for huge amounts of files.