### PR TITLE
ls: avoid `newfstatat` syscalls incritical path

### DIFF
--- a/tools/src/ls.c
+++ b/tools/src/ls.c
@@ -319,6 +319,9 @@ main(int argc, char *argv[]) {
 	image_path = argv[optind];
 	optind++;
 
+	// Having TZ be set to its default value prevents libc to repeatedly
+	// stat /etc/localtime for every localtime() call.
+	setenv("TZ", ":/etc/localtime", 0);
 	archive = open_archive(image_path, offset, &rv);
 	if (rv < 0) {
 		sqsh_perror(rv, image_path);


### PR DESCRIPTION
When calling `localtime(3)` by default it does a stat to `/etc/localtime`. It does that repeatedly for any call. As sqsh-ls has a short lifetime it would be enough (and also reduce the syscall overhead) to check it once.

Fortunally there's a workaround: These calls can be prevented by setting the TZ environment variable.[1]

This change sets the TZ variable if unset for `sqsh-ls` which greatly improves perfomance when listing many files.

[1] https://doc.dovecot.org/configuration_manual/system_calls_optimization/