### PR TITLE
file_iterator: dynamically allocate zero block

### DIFF
--- a/libsqsh/include/sqsh_archive_private.h
+++ b/libsqsh/include/sqsh_archive_private.h
@@ -225,6 +225,7 @@ struct SqshArchive {
 	uint8_t initialized;
 	struct SqshConfig config;
 	sqsh__mutex_t lock;
+	uint8_t *zero_block;
 };
 
 /**
@@ -269,6 +270,30 @@ SQSH_NO_EXPORT int sqsh__archive_data_extract_manager(
  */
 SQSH_NO_EXPORT struct SqshExtractManager *
 sqsh__archive_metablock_extract_manager(struct SqshArchive *archive);
+
+/**
+ * @internal
+ * @memberof SqshArchive
+ * @brief Returns a 16k block of zeros.
+ *
+ * @param archive the SqshArchive to retrieve the zero block from
+ *
+ * @return the SqshExtractManager.
+ */
+SQSH_NO_EXPORT const uint8_t *
+sqsh__archive_zero_block(const struct SqshArchive *archive);
+
+/**
+ * @internal
+ * @memberof SqshArchive
+ * @brief Returns a 16k block of zeros.
+ *
+ * @param archive the SqshArchive to retrieve the zero block from
+ *
+ * @return the SqshExtractManager.
+ */
+SQSH_NO_EXPORT size_t
+sqsh__archive_zero_block_size(const struct SqshArchive *archive);
 
 /**
  * @internal

--- a/libsqsh/src/file/file_iterator.c
+++ b/libsqsh/src/file/file_iterator.c
@@ -40,8 +40,6 @@
 
 #define BLOCK_INDEX_FINISHED UINT32_MAX
 
-static const uint8_t ZERO_BLOCK[16384] = {0};
-
 static bool
 is_last_block(const struct SqshFileIterator *iterator) {
 	const struct SqshFile *file = iterator->file;
@@ -188,15 +186,19 @@ out:
 
 static int
 map_zero_block(struct SqshFileIterator *iterator) {
+	const struct SqshFile *file = iterator->file;
+	const struct SqshArchive *archive = file->archive;
+	const size_t zero_block_size = sqsh__archive_zero_block_size(archive);
+
 	size_t current_sparse_size = iterator->sparse_size;
 
-	if (current_sparse_size > sizeof(ZERO_BLOCK)) {
-		current_sparse_size = sizeof(ZERO_BLOCK);
+	if (current_sparse_size > zero_block_size) {
+		current_sparse_size = zero_block_size;
 	}
 	iterator->sparse_size -= current_sparse_size;
 
 	iterator->size = current_sparse_size;
-	iterator->data = ZERO_BLOCK;
+	iterator->data = sqsh__archive_zero_block(archive);
 
 	return current_sparse_size;
 }


### PR DESCRIPTION
This change reintroduces a dynamically allocated zero block. For now it has a fixed size. In contrast to a fixed rodata segment, dynamic allocations do not increase the build artifact size.