### PR TITLE
file_iterator: Correctly set the sparse_size.

### DIFF
--- a/libsqsh/src/file/file_iterator.c
+++ b/libsqsh/src/file/file_iterator.c
@@ -217,7 +217,7 @@ map_block(struct SqshFileIterator *iterator, size_t desired_size) {
 			sqsh__map_reader_size(&iterator->map_reader);
 
 	if (data_block_size == 0) {
-		if (is_last_block(iterator) == false || file_size == block_size) {
+		if (is_last_block(iterator) == false || file_size % block_size == 0) {
 			iterator->sparse_size = block_size;
 		} else {
 			iterator->sparse_size = file_size % block_size;


### PR DESCRIPTION
Up to now sparse blocks at the end of a file were only calculated correctly for files that where exactly the size of a block.

This change fixes the behavior and introduces a test case to check for this behavior.