### PR TITLE
extract: fix tests when building with `-O2`

### DIFF
--- a/libsqsh/include/sqsh_extract_private.h
+++ b/libsqsh/include/sqsh_extract_private.h
@@ -60,7 +60,7 @@ typedef uint8_t sqsh__extractor_context_t[256];
  * If you want to use this, you need to link against
  * [libsqsh-lzo](https://github.com/Gottox/libsqsh-lzo).
  */
-extern const struct SqshExtractorImpl *const sqsh__impl_lzo;
+extern const struct SqshExtractorImpl *const volatile sqsh__impl_lzo;
 
 /**
  * @internal

--- a/libsqsh/src/extract/extractor.c
+++ b/libsqsh/src/extract/extractor.c
@@ -37,8 +37,11 @@
 #include <sqsh_archive.h>
 #include <sqsh_error.h>
 
-const struct SqshExtractorImpl *const __attribute__((weak)) sqsh__impl_lzo =
-		NULL;
+// sqsh__impl_lzo needs to be declared `volatile`. Otherwise when compiled with
+// `-O2` this value might get inlined which breaks a) the the tests and b) the
+// overloading of this extractor using LD_PRELOAD.
+const struct SqshExtractorImpl *volatile const __attribute__((weak))
+sqsh__impl_lzo = NULL;
 
 const struct SqshExtractorImpl *
 sqsh__extractor_impl_from_id(int id) {

--- a/test/libsqsh/archive/compression_options.c
+++ b/test/libsqsh/archive/compression_options.c
@@ -49,7 +49,7 @@
 
 // Make sure, that lzo compression is not NULL, otherwise libsqsh will refuse
 // to init the archive.
-const struct SqshExtractorImpl *const sqsh__impl_lzo = (void *)0x1;
+const struct SqshExtractorImpl *const volatile sqsh__impl_lzo = (void *)0x1;
 
 static void
 load_compression_options_gzip(void) {


### PR DESCRIPTION
When building with optimisations enabled `sqsh__impl_lzo` was inlined in `extractor.c` this caused the tests to be unable to override this value to fake an extractor implementation.

This bug also broke the libsqsh-lzo[1] library when building libsqsh with optimizations enabled.

This change marks `sqsh__impl_lzo` as `volatile` which prevents inlining.

[1] https://github.com/Gottox/libsqsh-lzo