### PR TITLE
introduce superblock_builder

### DIFF
--- a/common/include/sqsh_data_set.h
+++ b/common/include/sqsh_data_set.h
@@ -1,0 +1,84 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (c) 2023, Enno Boland <g@s01.de>                                 *
+ *                                                                            *
+ * Redistribution and use in source and binary forms, with or without         *
+ * modification, are permitted provided that the following conditions are     *
+ * met:                                                                       *
+ *                                                                            *
+ * * Redistributions of source code must retain the above copyright notice,   *
+ *   this list of conditions and the following disclaimer.                    *
+ * * Redistributions in binary form must reproduce the above copyright        *
+ *   notice, this list of conditions and the following disclaimer in the      *
+ *   documentation and/or other materials provided with the distribution.     *
+ *                                                                            *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS    *
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,  *
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR     *
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR          *
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,      *
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,        *
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR         *
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF     *
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING       *
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS         *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               *
+ *                                                                            *
+ ******************************************************************************/
+
+#ifndef SQSH_DATA_SET_H
+#define SQSH_DATA_SET_H
+
+#include "sqsh_data_private.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/***************************************
+ * data/superblock_data.c
+ */
+
+void sqsh__data_superblock_magic_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value);
+void sqsh__data_superblock_inode_count_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value);
+void sqsh__data_superblock_modification_time_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value);
+void sqsh__data_superblock_block_size_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value);
+void sqsh__data_superblock_fragment_entry_count_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value);
+void sqsh__data_superblock_compression_id_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value);
+void sqsh__data_superblock_block_log_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value);
+void sqsh__data_superblock_flags_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value);
+void sqsh__data_superblock_id_count_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value);
+void sqsh__data_superblock_version_major_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value);
+void sqsh__data_superblock_version_minor_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value);
+void sqsh__data_superblock_root_inode_ref_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value);
+void sqsh__data_superblock_bytes_used_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value);
+void sqsh__data_superblock_id_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value);
+void sqsh__data_superblock_xattr_id_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value);
+void sqsh__data_superblock_inode_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value);
+void sqsh__data_superblock_directory_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value);
+void sqsh__data_superblock_fragment_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value);
+void sqsh__data_superblock_export_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* SQSH_DATA_SET_H */

--- a/common/src/data/superblock_set.c
+++ b/common/src/data/superblock_set.c
@@ -1,0 +1,158 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (c) 2023, Enno Boland <g@s01.de>                                 *
+ *                                                                            *
+ * Redistribution and use in source and binary forms, with or without         *
+ * modification, are permitted provided that the following conditions are     *
+ * met:                                                                       *
+ *                                                                            *
+ * * Redistributions of source code must retain the above copyright notice,   *
+ *   this list of conditions and the following disclaimer.                    *
+ * * Redistributions in binary form must reproduce the above copyright        *
+ *   notice, this list of conditions and the following disclaimer in the      *
+ *   documentation and/or other materials provided with the distribution.     *
+ *                                                                            *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS    *
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,  *
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR     *
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR          *
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,      *
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,        *
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR         *
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF     *
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING       *
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS         *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               *
+ *                                                                            *
+ ******************************************************************************/
+
+/**
+ * @author       Enno Boland (mail@eboland.de)
+ * @file         superblock_data.c
+ */
+
+#define _DEFAULT_SOURCE
+
+#include <sqsh_data_set.h>
+
+#include <cextras/endian_compat.h>
+
+/***************************************
+ * data/superblock_data.c
+ */
+
+#include <endian.h> // for htoleXX functions
+
+void
+sqsh__data_superblock_magic_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value) {
+	superblock->magic = htole32(value);
+}
+
+void
+sqsh__data_superblock_inode_count_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value) {
+	superblock->inode_count = htole32(value);
+}
+
+void
+sqsh__data_superblock_modification_time_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value) {
+	superblock->modification_time = htole32(value);
+}
+
+void
+sqsh__data_superblock_block_size_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value) {
+	superblock->block_size = htole32(value);
+}
+
+void
+sqsh__data_superblock_fragment_entry_count_set(
+		struct SqshDataSuperblock *superblock, const uint32_t value) {
+	superblock->fragment_entry_count = htole32(value);
+}
+
+void
+sqsh__data_superblock_compression_id_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value) {
+	superblock->compression_id = htole16(value);
+}
+
+void
+sqsh__data_superblock_block_log_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value) {
+	superblock->block_log = htole16(value);
+}
+
+void
+sqsh__data_superblock_flags_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value) {
+	superblock->flags = htole16(value);
+}
+
+void
+sqsh__data_superblock_id_count_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value) {
+	superblock->id_count = htole16(value);
+}
+
+void
+sqsh__data_superblock_version_major_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value) {
+	superblock->version_major = htole16(value);
+}
+
+void
+sqsh__data_superblock_version_minor_set(
+		struct SqshDataSuperblock *superblock, const uint16_t value) {
+	superblock->version_minor = htole16(value);
+}
+
+void
+sqsh__data_superblock_root_inode_ref_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value) {
+	superblock->root_inode_ref = htole64(value);
+}
+
+void
+sqsh__data_superblock_bytes_used_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value) {
+	superblock->bytes_used = htole64(value);
+}
+
+void
+sqsh__data_superblock_id_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value) {
+	superblock->id_table_start = htole64(value);
+}
+
+void
+sqsh__data_superblock_xattr_id_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value) {
+	superblock->xattr_id_table_start = htole64(value);
+}
+
+void
+sqsh__data_superblock_inode_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value) {
+	superblock->inode_table_start = htole64(value);
+}
+
+void
+sqsh__data_superblock_directory_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value) {
+	superblock->directory_table_start = htole64(value);
+}
+
+void
+sqsh__data_superblock_fragment_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value) {
+	superblock->fragment_table_start = htole64(value);
+}
+
+void
+sqsh__data_superblock_export_table_start_set(
+		struct SqshDataSuperblock *superblock, const uint64_t value) {
+	superblock->export_table_start = htole64(value);
+}

--- a/common/src/meson.build
+++ b/common/src/meson.build
@@ -5,6 +5,7 @@ libsqsh_common_sources = files(
     'data/inode_data.c',
     'data/metablock_data.c',
     'data/superblock_data.c',
+    'data/superblock_set.c',
     'data/xattr_data.c',
     'reader/reader.c',
     'utils/thread.c',

--- a/libmksqsh/include/meson.build
+++ b/libmksqsh/include/meson.build
@@ -1,0 +1,5 @@
+libmksqsh_headers = files(
+    'sqsh_archive_builder.h',
+)
+
+libmksqsh_include = include_directories('.')

--- a/libmksqsh/include/sqsh_archive_builder.h
+++ b/libmksqsh/include/sqsh_archive_builder.h
@@ -1,0 +1,132 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (c) 2023, Enno Boland <g@s01.de>                                 *
+ *                                                                            *
+ * Redistribution and use in source and binary forms, with or without         *
+ * modification, are permitted provided that the following conditions are     *
+ * met:                                                                       *
+ *                                                                            *
+ * * Redistributions of source code must retain the above copyright notice,   *
+ *   this list of conditions and the following disclaimer.                    *
+ * * Redistributions in binary form must reproduce the above copyright        *
+ *   notice, this list of conditions and the following disclaimer in the      *
+ *   documentation and/or other materials provided with the distribution.     *
+ *                                                                            *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS    *
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,  *
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR     *
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR          *
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,      *
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,        *
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR         *
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF     *
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING       *
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS         *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               *
+ *                                                                            *
+ ******************************************************************************/
+
+/**
+ * @author       Enno Boland (mail@eboland.de)
+ * @file         sqsh_archive_builder.h
+ */
+
+#ifndef SQSH_ARCHIVE_BUILDER_H
+#define SQSH_ARCHIVE_BUILDER_H
+
+#include <cextras/collection.h>
+#include <sqsh_data.h>
+#include <sqsh_data_set.h>
+
+#include <stdio.h>
+
+/***************************************
+ * archive/superblock_builder.c
+ */
+
+struct SqshSuperblockBuilder {
+	struct SqshDataSuperblock data;
+	uint16_t flags;
+};
+
+int sqsh__superblock_builder_init(struct SqshSuperblockBuilder *superblock);
+
+int sqsh__superblock_builder_modification_time(
+		struct SqshSuperblockBuilder *superblock, uint32_t mtime);
+
+int sqsh__superblock_builder_block_size(
+		struct SqshSuperblockBuilder *superblock, uint32_t block_size);
+
+int sqsh__superblock_builder_fragment_count(
+		struct SqshSuperblockBuilder *superblock, uint32_t fragment_count);
+
+int sqsh__superblock_builder_compression_id(
+		struct SqshSuperblockBuilder *superblock,
+		enum SqshSuperblockCompressionId compression_id);
+
+int sqsh__superblock_builder_compress_inodes(
+		struct SqshSuperblockBuilder *superblock, bool compress_inodes);
+
+int sqsh__superblock_builder_compress_data(
+		struct SqshSuperblockBuilder *superblock, bool compress_data);
+
+int sqsh__superblock_builder_compress_fragments(
+		struct SqshSuperblockBuilder *superblock, bool compress_fragments);
+
+int sqsh__superblock_builder_force_fragments(
+		struct SqshSuperblockBuilder *superblock, bool force_fragments);
+
+int sqsh__superblock_builder_deduplicate(
+		struct SqshSuperblockBuilder *superblock, bool deduplicate);
+
+int sqsh__superblock_builder_compress_xattr(
+		struct SqshSuperblockBuilder *superblock, bool compress_export);
+
+int sqsh__superblock_builder_compression_options(
+		struct SqshSuperblockBuilder *superblock, bool compression_options);
+
+int sqsh__superblock_builder_id_count(
+		struct SqshSuperblockBuilder *superblock, uint32_t id_count);
+
+int sqsh__superblock_builder_root_inode_ref(
+		struct SqshSuperblockBuilder *superblock, uint64_t root_inode_ref);
+
+int sqsh__superblock_builder_inode_count(
+		struct SqshSuperblockBuilder *superblock, uint32_t inode_count);
+
+int sqsh__superblock_builder_bytes_used(
+		struct SqshSuperblockBuilder *superblock, uint64_t bytes_used);
+
+int sqsh__superblock_builder_id_table_start(
+		struct SqshSuperblockBuilder *superblock, uint64_t id_table_start);
+
+int sqsh__superblock_builder_xattr_table_start(
+		struct SqshSuperblockBuilder *superblock,
+		uint64_t xattr_id_table_start);
+
+int sqsh__superblock_builder_inode_table_start(
+		struct SqshSuperblockBuilder *superblock, uint64_t inode_table_start);
+
+int sqsh__superblock_builder_directory_table_start(
+		struct SqshSuperblockBuilder *superblock, uint64_t inode_table_start);
+
+int sqsh__superblock_builder_fragment_table_start(
+		struct SqshSuperblockBuilder *superblock,
+		uint64_t export_fragment_table_start);
+
+int sqsh__superblock_builder_export_table_start(
+		struct SqshSuperblockBuilder *superblock, uint64_t export_table_start);
+
+int sqsh__superblock_builder_fragment_table(
+		struct SqshSuperblockBuilder *superblock,
+		uint64_t fragment_table_start);
+
+int sqsh__superblock_builder_write(
+		struct SqshSuperblockBuilder *superblock, FILE *output);
+
+int sqsh__superblock_builder_cleanup(struct SqshSuperblockBuilder *superblock);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* SQSH_ARCHIVE_BUILDER_H */

--- a/libmksqsh/meson.build
+++ b/libmksqsh/meson.build
@@ -1,0 +1,28 @@
+subdir('src')
+
+subdir('include')
+
+libmksqsh_dependencies = [
+    cextras_dep,
+    libsqsh_dep,
+    libsqsh_common_dep,
+]
+
+c_args = []
+if threads_dep.found()
+    libmksqsh_dependencies += threads_dep
+endif
+
+libmksqsh = both_libraries(
+    'mksqsh',
+    libmksqsh_sources,
+    include_directories: [
+        libsqsh_private_include,
+        libmksqsh_include,
+    ],
+
+    install: false,
+    c_args: c_args,
+    dependencies: libmksqsh_dependencies,
+    version: meson.project_version(),
+)

--- a/libmksqsh/src/archive/superblock_builder.c
+++ b/libmksqsh/src/archive/superblock_builder.c
@@ -1,0 +1,289 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (c) 2023, Enno Boland <g@s01.de>                                 *
+ *                                                                            *
+ * Redistribution and use in source and binary forms, with or without         *
+ * modification, are permitted provided that the following conditions are     *
+ * met:                                                                       *
+ *                                                                            *
+ * * Redistributions of source code must retain the above copyright notice,   *
+ *   this list of conditions and the following disclaimer.                    *
+ * * Redistributions in binary form must reproduce the above copyright        *
+ *   notice, this list of conditions and the following disclaimer in the      *
+ *   documentation and/or other materials provided with the distribution.     *
+ *                                                                            *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS    *
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,  *
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR     *
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR          *
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,      *
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,        *
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR         *
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF     *
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING       *
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS         *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               *
+ *                                                                            *
+ ******************************************************************************/
+
+/**
+ * @author       Enno Boland (mail@eboland.de)
+ * @file         superblock_builder.c
+ */
+
+#include <sqsh_data.h>
+#include <sqsh_data_set.h>
+#include <sqsh_error.h>
+
+#include <sqsh_archive_builder.h>
+
+static uint16_t
+log2_u32(uint32_t x) {
+	if (x == 0) {
+		return UINT16_MAX;
+	} else {
+		return sizeof(uint32_t) * 8 - 1 - __builtin_clz(x);
+	}
+}
+
+int
+sqsh__superblock_builder_init(struct SqshSuperblockBuilder *superblock) {
+	sqsh__data_superblock_magic_set(&superblock->data, SQSH_SUPERBLOCK_MAGIC);
+	sqsh__data_superblock_version_major_set(&superblock->data, 4);
+	sqsh__data_superblock_version_minor_set(&superblock->data, 0);
+
+	return sqsh__superblock_builder_block_size(superblock, 4096);
+}
+
+int
+sqsh__superblock_builder_modification_time(
+		struct SqshSuperblockBuilder *superblock, uint32_t mtime) {
+	sqsh__data_superblock_modification_time_set(&superblock->data, mtime);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_block_size(
+		struct SqshSuperblockBuilder *superblock, uint32_t block_size) {
+	if (block_size < 4096 || block_size > 1048576) {
+		return -SQSH_ERROR_BLOCKSIZE_MISMATCH;
+	}
+	if ((block_size & (block_size - 1)) != 0) {
+		return -SQSH_ERROR_BLOCKSIZE_MISMATCH;
+	}
+
+	sqsh__data_superblock_block_size_set(&superblock->data, block_size);
+	const uint16_t log2_block_size = log2_u32(block_size);
+	sqsh__data_superblock_block_log_set(&superblock->data, log2_block_size);
+
+	return 0;
+}
+
+int
+sqsh__superblock_builder_fragment_count(
+		struct SqshSuperblockBuilder *superblock, uint32_t fragment_count) {
+	sqsh__data_superblock_fragment_entry_count_set(
+			&superblock->data, fragment_count);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_compression_id(
+		struct SqshSuperblockBuilder *superblock,
+		enum SqshSuperblockCompressionId compression_id) {
+	sqsh__data_superblock_compression_id_set(&superblock->data, compression_id);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_compress_inodes(
+		struct SqshSuperblockBuilder *superblock, bool compress_inodes) {
+	if (compress_inodes) {
+		superblock->flags &= ~SQSH_SUPERBLOCK_UNCOMPRESSED_INODES;
+	} else {
+		superblock->flags |= SQSH_SUPERBLOCK_UNCOMPRESSED_INODES;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_compress_data(
+		struct SqshSuperblockBuilder *superblock, bool compress_data) {
+	if (compress_data) {
+		superblock->flags &= ~SQSH_SUPERBLOCK_UNCOMPRESSED_DATA;
+	} else {
+		superblock->flags |= SQSH_SUPERBLOCK_UNCOMPRESSED_DATA;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_compress_fragments(
+		struct SqshSuperblockBuilder *superblock, bool compress_fragments) {
+	if (compress_fragments) {
+		superblock->flags &= ~SQSH_SUPERBLOCK_UNCOMPRESSED_FRAGMENTS;
+	} else {
+		superblock->flags |= SQSH_SUPERBLOCK_UNCOMPRESSED_FRAGMENTS;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_force_fragments(
+		struct SqshSuperblockBuilder *superblock, bool force_fragments) {
+	if (force_fragments) {
+		superblock->flags &= ~SQSH_SUPERBLOCK_ALWAYS_FRAGMENTS;
+	} else {
+		superblock->flags |= SQSH_SUPERBLOCK_ALWAYS_FRAGMENTS;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_deduplicate(
+		struct SqshSuperblockBuilder *superblock, bool deduplicate) {
+	if (deduplicate) {
+		superblock->flags |= SQSH_SUPERBLOCK_DUPLICATES;
+	} else {
+		superblock->flags &= ~SQSH_SUPERBLOCK_DUPLICATES;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_compress_xattr(
+		struct SqshSuperblockBuilder *superblock, bool compress_export) {
+	if (compress_export) {
+		superblock->flags &= ~SQSH_SUPERBLOCK_UNCOMPRESSED_XATTRS;
+	} else {
+		superblock->flags |= SQSH_SUPERBLOCK_UNCOMPRESSED_XATTRS;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_compression_options(
+		struct SqshSuperblockBuilder *superblock, bool compression_options) {
+	if (compression_options) {
+		superblock->flags |= SQSH_SUPERBLOCK_COMPRESSOR_OPTIONS;
+	} else {
+		superblock->flags &= ~SQSH_SUPERBLOCK_COMPRESSOR_OPTIONS;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_id_count(
+		struct SqshSuperblockBuilder *superblock, uint32_t id_count) {
+	sqsh__data_superblock_id_count_set(&superblock->data, id_count);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_root_inode_ref(
+		struct SqshSuperblockBuilder *superblock, uint64_t root_inode_ref) {
+	sqsh__data_superblock_root_inode_ref_set(&superblock->data, root_inode_ref);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_inode_count(
+		struct SqshSuperblockBuilder *superblock, uint32_t inode_count) {
+	sqsh__data_superblock_inode_count_set(&superblock->data, inode_count);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_bytes_used(
+		struct SqshSuperblockBuilder *superblock, uint64_t bytes_used) {
+	sqsh__data_superblock_bytes_used_set(&superblock->data, bytes_used);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_id_table_start(
+		struct SqshSuperblockBuilder *superblock, uint64_t id_table_start) {
+	sqsh__data_superblock_id_table_start_set(&superblock->data, id_table_start);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_xattr_table_start(
+		struct SqshSuperblockBuilder *superblock,
+		uint64_t xattr_id_table_start) {
+	sqsh__data_superblock_xattr_id_table_start_set(
+			&superblock->data, xattr_id_table_start);
+	if (xattr_id_table_start == UINT64_MAX) {
+		superblock->flags |= SQSH_SUPERBLOCK_NO_XATTRS;
+	} else {
+		superblock->flags &= ~SQSH_SUPERBLOCK_NO_XATTRS;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_inode_table_start(
+		struct SqshSuperblockBuilder *superblock, uint64_t inode_table_start) {
+	sqsh__data_superblock_inode_table_start_set(
+			&superblock->data, inode_table_start);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_directory_table_start(
+		struct SqshSuperblockBuilder *superblock, uint64_t inode_table_start) {
+	sqsh__data_superblock_directory_table_start_set(
+			&superblock->data, inode_table_start);
+	return 0;
+}
+
+int
+sqsh__superblock_builder_fragment_table_start(
+		struct SqshSuperblockBuilder *superblock,
+		uint64_t export_fragment_table_start) {
+	sqsh__data_superblock_fragment_table_start_set(
+			&superblock->data, export_fragment_table_start);
+	if (export_fragment_table_start == UINT64_MAX) {
+		superblock->flags |= SQSH_SUPERBLOCK_NO_FRAGMENTS;
+	} else {
+		superblock->flags &= ~SQSH_SUPERBLOCK_NO_FRAGMENTS;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_export_table_start(
+		struct SqshSuperblockBuilder *superblock, uint64_t export_table_start) {
+	sqsh__data_superblock_export_table_start_set(
+			&superblock->data, export_table_start);
+	if (export_table_start == UINT64_MAX) {
+		superblock->flags |= SQSH_SUPERBLOCK_EXPORTABLE;
+	} else {
+		superblock->flags &= ~SQSH_SUPERBLOCK_EXPORTABLE;
+	}
+	return 0;
+}
+
+int
+sqsh__superblock_builder_write(
+		struct SqshSuperblockBuilder *superblock, FILE *output) {
+	int rv = 0;
+	struct SqshDataSuperblock *data = &superblock->data;
+
+	sqsh__data_superblock_flags_set(data, superblock->flags);
+	rv = fwrite(data, sizeof(*data), 1, output);
+	if (rv != 1) {
+		rv = -SQSH_ERROR_INTERNAL;
+		goto out;
+	}
+
+	rv = sizeof(*data);
+out:
+	return rv;
+}
+
+int
+sqsh__superblock_builder_cleanup(struct SqshSuperblockBuilder *superblock) {
+	(void)superblock;
+	return 0;
+}

--- a/libmksqsh/src/meson.build
+++ b/libmksqsh/src/meson.build
@@ -1,0 +1,3 @@
+libmksqsh_sources = files(
+    'archive/superblock_builder.c',
+)

--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,8 @@ subdir('common')
 
 subdir('libsqsh')
 
+subdir('libmksqsh')
+
 if get_option('examples')
     subdir('examples')
 endif

--- a/test/libsqsh/meson.build
+++ b/test/libsqsh/meson.build
@@ -95,8 +95,9 @@ foreach p : sqsh_test
             libsqsh_include,
             libsqsh_common_include,
             libsqsh_private_include,
+            libmksqsh_include,
         ],
-        link_with: libsqsh.get_static_lib(),
+        link_with: [libsqsh.get_static_lib(), libmksqsh.get_static_lib()],
         dependencies: [threads_dep, testlib_dep, cextras_dep],
     )
     test(p, t)

--- a/test/libsqsh/util.c
+++ b/test/libsqsh/util.c
@@ -4,65 +4,79 @@
  * @created     : Saturday Feb 18, 2023 14:06:14 CET
  */
 
+// for fmemopen
+#define _POSIX_C_SOURCE 200809L
+
 #include "common.h"
 
+#include <sqsh_archive_builder.h>
 #include <sqsh_archive_private.h>
 #include <sqsh_data_private.h>
 #include <sqsh_mapper.h>
-
-#include <assert.h>
 
 const uint8_t *
 mk_stub(struct SqshArchive *sqsh, uint8_t *payload, size_t payload_size) {
 	int rv;
 	const int compression_id =
 			payload[20] ? payload[20] : SQSH_COMPRESSION_GZIP;
-	uint8_t superblock[sizeof(struct SqshDataSuperblock)] = {
-			/* magic */
-			UINT32_BYTES(SQSH_SUPERBLOCK_MAGIC),
-			/* inode_count */
-			UINT32_BYTES(100),
-			/* modification_time */
-			UINT32_BYTES(0),
-			/* block_size */
-			UINT32_BYTES(32768),
-			/* fragment_entry_count */
-			UINT32_BYTES(0),
-			/* compression_id */
-			UINT16_BYTES(compression_id),
-			/* block_log */
-			UINT16_BYTES(15),
-			/* flags */
-			UINT16_BYTES(0),
-			/* id_count */
-			UINT16_BYTES(0),
-			/* version_major */
-			UINT16_BYTES(4),
-			/* version_minor */
-			UINT16_BYTES(0),
-			/* root_inode_ref */
-			UINT64_BYTES((uint64_t)0),
-			/* bytes_used */
-			UINT64_BYTES((uint64_t)payload_size),
-			/* id_table_start */
-			UINT64_BYTES((uint64_t)ID_TABLE_OFFSET),
-			UINT64_BYTES(
-					/* xattr_id_table_start */
-					(uint64_t)XATTR_TABLE_OFFSET),
-			/* inode_table_start */
-			UINT64_BYTES((uint64_t)INODE_TABLE_OFFSET),
-			/* Setting the directory table start to the end
-			 * of the archive so the inode tests don't fail */
-			UINT64_BYTES((uint64_t)
-						 /* directory_table_start */
-						 DIRECTORY_TABLE_OFFSET),
-			/* fragment_table_start */
-			UINT64_BYTES((uint64_t)FRAGMENT_TABLE_OFFSET),
-			/* export_table_start */
-			UINT64_BYTES((uint64_t)EXPORT_TABLE_OFFSET),
-	};
-
-	memcpy(payload, &superblock, sizeof(struct SqshDataSuperblock));
+	struct SqshSuperblockBuilder builder = {0};
+	FILE *fsuperblock =
+			fmemopen(payload, sizeof(struct SqshDataSuperblock), "w");
+	assert(fsuperblock);
+	rv = sqsh__superblock_builder_init(&builder);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_fragment_count(&builder, 0);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_compress_inodes(&builder, true);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_compress_data(&builder, true);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_compress_fragments(&builder, true);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_force_fragments(&builder, true);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_deduplicate(&builder, true);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_compress_xattr(&builder, true);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_compression_options(&builder, true);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_id_count(&builder, 0);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_inode_count(&builder, 100);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_root_inode_ref(&builder, 0);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_modification_time(&builder, 0);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_block_size(&builder, 32768);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_compression_id(&builder, compression_id);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_bytes_used(&builder, payload_size);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_id_table_start(&builder, ID_TABLE_OFFSET);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_xattr_table_start(
+			&builder, XATTR_TABLE_OFFSET);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_inode_table_start(
+			&builder, INODE_TABLE_OFFSET);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_directory_table_start(
+			&builder, DIRECTORY_TABLE_OFFSET);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_fragment_table_start(
+			&builder, FRAGMENT_TABLE_OFFSET);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_export_table_start(
+			&builder, EXPORT_TABLE_OFFSET);
+	assert(rv == 0);
+	rv = sqsh__superblock_builder_write(&builder, fsuperblock);
+	assert(rv == sizeof(struct SqshDataSuperblock));
+	rv = sqsh__superblock_builder_cleanup(&builder);
+	assert(rv == 0);
+	fclose(fsuperblock);
 
 	const struct SqshConfig config = DEFAULT_CONFIG(payload_size);
 	rv = sqsh__archive_init(sqsh, payload, &config);


### PR DESCRIPTION
This change introduces the first part of write support for libsqsh. The superblock_builder is a helper to create a superblock. It is currently used by the tests to generate the superblock for the test archive.