### PR TITLE
file: use own getter for the symlink size

### DIFF
--- a/libsqsh/include/sqsh_file_private.h
+++ b/libsqsh/include/sqsh_file_private.h
@@ -230,6 +230,7 @@ struct SqshInodeImpl {
 	uint32_t (*directory_parent_inode)(const struct SqshDataInode *inode);
 
 	const char *(*symlink_target_path)(const struct SqshDataInode *inode);
+	uint32_t (*symlink_target_size)(const struct SqshDataInode *inode);
 
 	uint32_t (*device_id)(const struct SqshDataInode *inode);
 

--- a/libsqsh/src/file/file.c
+++ b/libsqsh/src/file/file.c
@@ -330,7 +330,7 @@ sqsh_file_symlink_dup(const struct SqshFile *inode) {
 
 uint32_t
 sqsh_file_symlink_size(const struct SqshFile *context) {
-	return (uint32_t)sqsh_file_size(context);
+	return context->impl->symlink_target_size(get_inode(context));
 }
 
 uint32_t

--- a/libsqsh/src/file/inode_device.c
+++ b/libsqsh/src/file/inode_device.c
@@ -103,6 +103,7 @@ const struct SqshInodeImpl sqsh__inode_device_impl = {
 		.directory_parent_inode = sqsh__file_inode_null_directory_parent_inode,
 
 		.symlink_target_path = sqsh__file_inode_null_symlink_target_path,
+		.symlink_target_size = sqsh__file_inode_null_symlink_target_size,
 
 		.device_id = inode_device_id,
 
@@ -126,6 +127,7 @@ const struct SqshInodeImpl sqsh__inode_device_ext_impl = {
 		.directory_parent_inode = sqsh__file_inode_null_directory_parent_inode,
 
 		.symlink_target_path = sqsh__file_inode_null_symlink_target_path,
+		.symlink_target_size = sqsh__file_inode_null_symlink_target_size,
 
 		.device_id = inode_device_ext_id,
 

--- a/libsqsh/src/file/inode_directory.c
+++ b/libsqsh/src/file/inode_directory.c
@@ -141,6 +141,7 @@ const struct SqshInodeImpl sqsh__inode_directory_impl = {
 		.directory_parent_inode = inode_directory_parent_inode,
 
 		.symlink_target_path = sqsh__file_inode_null_symlink_target_path,
+		.symlink_target_size = sqsh__file_inode_null_symlink_target_size,
 
 		.device_id = sqsh__file_inode_null_device_id,
 
@@ -164,6 +165,7 @@ const struct SqshInodeImpl sqsh__inode_directory_ext_impl = {
 		.directory_parent_inode = inode_directory_ext_parent_inode,
 
 		.symlink_target_path = sqsh__file_inode_null_symlink_target_path,
+		.symlink_target_size = sqsh__file_inode_null_symlink_target_size,
 
 		.device_id = sqsh__file_inode_null_device_id,
 

--- a/libsqsh/src/file/inode_file.c
+++ b/libsqsh/src/file/inode_file.c
@@ -175,6 +175,7 @@ const struct SqshInodeImpl sqsh__inode_file_impl = {
 		.directory_parent_inode = sqsh__file_inode_null_directory_parent_inode,
 
 		.symlink_target_path = sqsh__file_inode_null_symlink_target_path,
+		.symlink_target_size = sqsh__file_inode_null_symlink_target_size,
 
 		.device_id = sqsh__file_inode_null_device_id,
 
@@ -198,6 +199,7 @@ const struct SqshInodeImpl sqsh__inode_file_ext_impl = {
 		.directory_parent_inode = sqsh__file_inode_null_directory_parent_inode,
 
 		.symlink_target_path = sqsh__file_inode_null_symlink_target_path,
+		.symlink_target_size = sqsh__file_inode_null_symlink_target_size,
 
 		.device_id = sqsh__file_inode_null_device_id,
 

--- a/libsqsh/src/file/inode_ipc.c
+++ b/libsqsh/src/file/inode_ipc.c
@@ -89,6 +89,7 @@ const struct SqshInodeImpl sqsh__inode_ipc_impl = {
 		.directory_parent_inode = sqsh__file_inode_null_directory_parent_inode,
 
 		.symlink_target_path = sqsh__file_inode_null_symlink_target_path,
+		.symlink_target_size = sqsh__file_inode_null_symlink_target_size,
 
 		.device_id = sqsh__file_inode_null_device_id,
 
@@ -112,6 +113,7 @@ const struct SqshInodeImpl sqsh__inode_ipc_ext_impl = {
 		.directory_parent_inode = sqsh__file_inode_null_directory_parent_inode,
 
 		.symlink_target_path = sqsh__file_inode_null_symlink_target_path,
+		.symlink_target_size = sqsh__file_inode_null_symlink_target_size,
 
 		.device_id = sqsh__file_inode_null_device_id,
 

--- a/libsqsh/src/file/inode_null.c
+++ b/libsqsh/src/file/inode_null.c
@@ -95,6 +95,12 @@ sqsh__file_inode_null_symlink_target_path(const struct SqshDataInode *inode) {
 }
 
 uint32_t
+sqsh__file_inode_null_symlink_target_size(const struct SqshDataInode *inode) {
+	(void)inode;
+	return 0;
+}
+
+uint32_t
 sqsh__file_inode_null_device_id(const struct SqshDataInode *inode) {
 	(void)inode;
 	return UINT32_MAX;

--- a/libsqsh/src/file/inode_symlink.c
+++ b/libsqsh/src/file/inode_symlink.c
@@ -43,22 +43,23 @@
 #include <sqsh_tree_private.h>
 #include <stdint.h>
 
-static uint64_t inode_symlink_size(const struct SqshDataInode *inode);
-static uint64_t inode_symlink_ext_size(const struct SqshDataInode *inode);
+static uint32_t inode_symlink_target_size(const struct SqshDataInode *inode);
+static uint32_t
+inode_symlink_ext_target_size(const struct SqshDataInode *inode);
 
 /* payload_size */
 static size_t
 inode_symlink_payload_size(
 		const struct SqshDataInode *inode, const struct SqshArchive *archive) {
 	(void)archive;
-	return inode_symlink_size(inode);
+	return inode_symlink_target_size(inode);
 }
 
 static size_t
 inode_symlink_ext_payload_size(
 		const struct SqshDataInode *inode, const struct SqshArchive *archive) {
 	(void)archive;
-	return inode_symlink_ext_size(inode);
+	return inode_symlink_ext_target_size(inode);
 }
 
 /* hard_link_count */
@@ -77,20 +78,30 @@ inode_symlink_ext_hard_link_count(const struct SqshDataInode *inode) {
 /* size */
 static uint64_t
 inode_symlink_size(const struct SqshDataInode *inode) {
-	return sqsh__data_inode_symlink_target_size(
-			sqsh__data_inode_symlink(inode));
+	return inode_symlink_target_size(inode);
 }
 
 static uint64_t
 inode_symlink_ext_size(const struct SqshDataInode *inode) {
-	return sqsh__data_inode_symlink_ext_target_size(
-			sqsh__data_inode_symlink_ext(inode));
+	return inode_symlink_ext_target_size(inode);
 }
 
 static const char *
 inode_symlink_target_path(const struct SqshDataInode *inode) {
 	return (const char *)sqsh__data_inode_symlink_ext_target_path(
 			sqsh__data_inode_symlink_ext(inode));
+}
+
+static uint32_t
+inode_symlink_ext_target_size(const struct SqshDataInode *inode) {
+	return sqsh__data_inode_symlink_ext_target_size(
+			sqsh__data_inode_symlink_ext(inode));
+}
+
+static uint32_t
+inode_symlink_target_size(const struct SqshDataInode *inode) {
+	return sqsh__data_inode_symlink_target_size(
+			sqsh__data_inode_symlink(inode));
 }
 
 static const char *
@@ -122,6 +133,7 @@ const struct SqshInodeImpl sqsh__inode_symlink_impl = {
 		.directory_parent_inode = sqsh__file_inode_null_directory_parent_inode,
 
 		.symlink_target_path = inode_symlink_target_path,
+		.symlink_target_size = inode_symlink_target_size,
 
 		.device_id = sqsh__file_inode_null_device_id,
 
@@ -145,6 +157,7 @@ const struct SqshInodeImpl sqsh__inode_symlink_ext_impl = {
 		.directory_parent_inode = sqsh__file_inode_null_directory_parent_inode,
 
 		.symlink_target_path = inode_symlink_ext_target_path,
+		.symlink_target_size = inode_symlink_ext_target_size,
 
 		.device_id = sqsh__file_inode_null_device_id,
 


### PR DESCRIPTION
This change adds a new getter to retrieve the size of a symlink. Before this change the file_size getter was used to retrieve the size. This resulted in situations where the file size could be misinterpreted as a length for a symlink even though the file wasn't a symlink.