### PR TITLE
ls: escape output filename paths

### DIFF
--- a/tools/src/ls.c
+++ b/tools/src/ls.c
@@ -71,6 +71,63 @@ print_mode(
 }
 
 static void
+print_segment(const char *segment, size_t segment_size) {
+	for (size_t i = 0; i < segment_size; i++) {
+		switch (segment[i]) {
+		case '\n':
+			fputs("\\n", stdout);
+			break;
+		case '\r':
+			fputs("\\r", stdout);
+			break;
+		case '\t':
+			fputs("\\t", stdout);
+			break;
+		case '\\':
+			fputs("\\\\", stdout);
+			break;
+		case '\x1b':
+			fputs("\\e", stdout);
+			break;
+		case 0x01:
+		case 0x02:
+		case 0x03:
+		case 0x04:
+		case 0x05:
+		case 0x06:
+		case 0x07:
+		case 0x08:
+		case 0x0b:
+		case 0x0c:
+		case 0x0e:
+		case 0x0f:
+		case 0x10:
+		case 0x11:
+		case 0x12:
+		case 0x13:
+		case 0x14:
+		case 0x15:
+		case 0x16:
+		case 0x17:
+		case 0x18:
+		case 0x19:
+		case 0x1a:
+		case 0x1c:
+		case 0x1d:
+		case 0x1e:
+		case 0x1f:
+		case 0x20:
+		case 0x7f:
+			printf("\\x%02x", segment[i]);
+			break;
+		default:
+			putchar(segment[i]);
+			break;
+		}
+	}
+}
+
+static void
 print_path(const char *path, const struct SqshTreeTraversal *traversal) {
 	fputs(path, stdout);
 	size_t segment_count = sqsh_tree_traversal_depth(traversal);
@@ -79,7 +136,7 @@ print_path(const char *path, const struct SqshTreeTraversal *traversal) {
 	for (size_t i = 0; i < segment_count; i++) {
 		segment = sqsh_tree_traversal_path_segment(traversal, &segment_size, i);
 		putchar('/');
-		fwrite(segment, segment_size, sizeof(char), stdout);
+		print_segment(segment, segment_size);
 	}
 }
 


### PR DESCRIPTION
This change makes ls escape the output filename paths, so that filenames with control characters do not mess up the output.