### PR TITLE
unpack: fix dangling file stream

### DIFF
--- a/tools/src/unpack.c
+++ b/tools/src/unpack.c
@@ -185,7 +185,6 @@ extract_file(
 		rv = EXIT_FAILURE;
 		goto out;
 	}
-	fclose(stream);
 
 	rv = rename(tmp_filename, filename);
 	if (rv < 0 && errno != ENOENT) {
@@ -193,6 +192,9 @@ extract_file(
 		goto out;
 	}
 out:
+	if (stream != NULL) {
+		fclose(stream);
+	}
 	return rv;
 }
 


### PR DESCRIPTION
When unpacking a file fails, the file stream was not closed before returning. This patch fixes this issue by closing the file stream before returning.