### PR TITLE
file: use the inode reference for the parent directory.

### DIFF
--- a/libsqsh/include/sqsh_file_private.h
+++ b/libsqsh/include/sqsh_file_private.h
@@ -207,6 +207,8 @@ SQSH_NO_EXPORT int sqsh__file_reader_cleanup(struct SqshFileReader *reader);
  * file/file.c
  */
 
+#define SQSH_INODE_REF_NULL UINT64_MAX
+
 /**
  * @brief The file type implementation
  */
@@ -249,8 +251,7 @@ struct SqshFile {
 	struct SqshArchive *archive;
 	const struct SqshInodeImpl *impl;
 	enum SqshFileType type;
-	bool has_dir_inode;
-	uint32_t dir_inode;
+	uint64_t parent_inode_ref;
 };
 
 /**
@@ -271,35 +272,24 @@ SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__file_init(
 
 /**
  * @memberof SqshFile
- * @brief returns whether the file is an extended structure.
+ * @brief sets the parent inode reference.
  *
  * @param[in] context The file context.
- * @param[in] dir_inode The inode of the parent directory.
+ * @param[in] parent_inode_ref The inode reference of the parent directory.
+ */
+SQSH_NO_EXPORT void sqsh__file_set_parent_inode_ref(
+		struct SqshFile *context, uint64_t parent_inode_ref);
+
+/**
+ * @memberof SqshFile
+ * @brief returns the parent inode reference if possible.
+ *
+ * @param[in] context The file context.
+ * @param[out] err Pointer to an int where the error code will be stored.
  *
  * @return int 0 on success, less than 0 on error.
  */
-SQSH_NO_EXPORT SQSH_NO_UNUSED int
-sqsh__file_set_dir_inode(struct SqshFile *context, uint32_t dir_inode);
-
-/**
- * @internal
- * @memberof SqshFile
- * @brief Retrieves the inode of the parent directory.
- *
- * @param context The file context.
- * @return The inode number.
- */
-SQSH_NO_EXPORT uint32_t sqsh__file_dir_inode(const struct SqshFile *context);
-
-/**
- * @internal
- * @memberof SqshFile
- * @brief Retrieves if the inode of the parent directory is set.
- *
- * @param context The file context.
- * @return true if the dir_inode is set, false otherwise.
- */
-SQSH_NO_EXPORT bool sqsh__file_has_dir_inode(const struct SqshFile *context);
+uint64_t sqsh__file_parent_inode_ref(struct SqshFile *context, int *err);
 
 /**
  * @internal

--- a/libsqsh/src/archive/inode_map.c
+++ b/libsqsh/src/archive/inode_map.c
@@ -38,8 +38,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define EMPTY_INODE_REF UINT64_MAX
-
 // Funfact: In older versions of this library, the inode map used `0` as the
 // sentinal value for empty inodes. It turned out that this was a bad idea,
 // because `0` is a valid inode_ref (even if it is an invalid inode number
@@ -145,7 +143,7 @@ dyn_map_get(const struct SqshInodeMap *map, uint32_t inode_number, int *err) {
 		goto out;
 	}
 	inode_ref = ~inner_inode_refs[inner_index];
-	if (inode_ref == EMPTY_INODE_REF) {
+	if (inode_ref == SQSH_INODE_REF_NULL) {
 		rv = -SQSH_ERROR_NO_SUCH_ELEMENT;
 		inode_ref = 0;
 		goto out;
@@ -167,7 +165,7 @@ dyn_map_set(
 		struct SqshInodeMap *map, uint32_t inode_number, uint64_t inode_ref) {
 	int rv = 0;
 
-	if (inode_ref == EMPTY_INODE_REF) {
+	if (inode_ref == SQSH_INODE_REF_NULL) {
 		return -SQSH_ERROR_INVALID_ARGUMENT;
 	} else if (inode_number == 0 || inode_number - 1 >= map->inode_count) {
 		return -SQSH_ERROR_OUT_OF_BOUNDS;
@@ -191,7 +189,7 @@ dyn_map_set(
 	} else {
 		const uint64_t old_value = ~inner_inode_refs[inner_index];
 		inner_inode_refs[inner_index] = ~inode_ref;
-		if (old_value != EMPTY_INODE_REF && old_value != inode_ref) {
+		if (old_value != SQSH_INODE_REF_NULL && old_value != inode_ref) {
 			rv = -SQSH_ERROR_INODE_MAP_IS_INCONSISTENT;
 			goto out;
 		}

--- a/libsqsh/src/directory/directory_iterator.c
+++ b/libsqsh/src/directory/directory_iterator.c
@@ -406,7 +406,7 @@ sqsh_directory_iterator_open_file(
 	int rv = 0;
 	struct SqshFile *file = NULL;
 	const uint64_t inode_ref = sqsh_directory_iterator_inode_ref(iterator);
-	const uint32_t dir_inode = sqsh_file_inode(iterator->file);
+	const uint64_t parent_inode_ref = sqsh_file_inode_ref(iterator->file);
 	struct SqshArchive *archive = iterator->file->archive;
 
 	file = sqsh_open_by_ref(archive, inode_ref, &rv);
@@ -414,10 +414,7 @@ sqsh_directory_iterator_open_file(
 		goto out;
 	}
 
-	rv = sqsh__file_set_dir_inode(file, dir_inode);
-	if (rv < 0) {
-		goto out;
-	}
+	sqsh__file_set_parent_inode_ref(file, parent_inode_ref);
 
 	rv = check_file_consistency(iterator, file);
 

--- a/libsqsh/src/tree/traversal.c
+++ b/libsqsh/src/tree/traversal.c
@@ -79,17 +79,15 @@ push_stack(struct SqshTreeTraversal *traversal) {
 	traversal->stack = element;
 
 	struct SqshArchive *archive = traversal->base_file->archive;
-	const uint32_t dir_inode = sqsh_file_inode(traversal->current_file);
+	const uint64_t parent_inode_ref =
+			sqsh_file_inode_ref(traversal->current_file);
 	const uint64_t inode_ref =
 			sqsh_directory_iterator_inode_ref(traversal->current_iterator);
 	rv = sqsh__file_init(&element->file, archive, inode_ref);
 	if (rv < 0) {
 		goto out;
 	}
-	rv = sqsh__file_set_dir_inode(&element->file, dir_inode);
-	if (rv < 0) {
-		goto out;
-	}
+	sqsh__file_set_parent_inode_ref(&element->file, parent_inode_ref);
 	traversal->current_file = &element->file;
 	traversal->state = SQSH_TREE_TRAVERSAL_STATE_DIRECTORY_BEGIN;
 out:
@@ -348,11 +346,8 @@ sqsh_tree_traversal_open_file(
 		if (rv < 0) {
 			goto out;
 		}
-		if (sqsh__file_has_dir_inode(traversal->base_file)) {
-			const uint32_t dir_inode =
-					sqsh__file_dir_inode(traversal->base_file);
-			rv = sqsh__file_set_dir_inode(file, dir_inode);
-		}
+		sqsh__file_set_parent_inode_ref(
+				file, traversal->base_file->parent_inode_ref);
 	} else {
 		file = sqsh_directory_iterator_open_file(
 				traversal->current_iterator, &rv);

--- a/test/libsqsh/file/file.c
+++ b/test/libsqsh/file/file.c
@@ -152,8 +152,7 @@ UTEST(file, resolve_unkown_dir_inode) {
 	struct SqshFile *symlink = sqsh_lopen(&archive, "/src", &rv);
 	ASSERT_EQ(0, rv);
 	ASSERT_EQ(SQSH_FILE_TYPE_SYMLINK, sqsh_file_type(symlink));
-	symlink->dir_inode = 0;
-	symlink->has_dir_inode = false;
+	symlink->parent_inode_ref = UINT64_MAX;
 
 	rv = sqsh_file_symlink_resolve(symlink);
 	ASSERT_EQ(-SQSH_ERROR_INODE_PARENT_UNSET, rv);

--- a/test/libsqsh/tree/traversal.c
+++ b/test/libsqsh/tree/traversal.c
@@ -74,8 +74,6 @@ UTEST(traversal, test_recursive_directory) {
 	struct SqshFile file = {0};
 	rv = sqsh__file_init(&file, &archive, 0);
 	ASSERT_EQ(0, rv);
-	rv = sqsh__file_set_dir_inode(&file, 2);
-	ASSERT_EQ(0, rv);
 
 	struct SqshTreeTraversal traversal = {0};
 	rv = sqsh__tree_traversal_init(&traversal, &file);


### PR DESCRIPTION
This change removes the `dir_inode` field from the `SqshFile` structure and replaces it with a `parent_inode_ref` field. This field is used to store the inode reference of the parent directory. This reduces the number of inode lookups required to resolve the parent directory of a file.