### PR TITLE
file: remove unkown file type

### DIFF
--- a/include/sqsh_file.h
+++ b/include/sqsh_file.h
@@ -237,11 +237,13 @@ int sqsh_file_iterator_free(struct SqshFileIterator *iterator);
  */
 #define SQSH_INODE_NO_XATTR 0xFFFFFFFF
 
+__attribute__((deprecated(
+		"Since 1.5.0. libsqsh should never return this."))) static const int
+		SQSH_FILE_TYPE_UNKNOWN = -1;
 /**
  * @brief enum that represents the file type.
  */
 enum SqshFileType {
-	SQSH_FILE_TYPE_UNKNOWN = -1,
 	/* avoid overlapping with the types in inode_data.h */
 	SQSH_FILE_TYPE_DIRECTORY = 1 + (1 << 8),
 	SQSH_FILE_TYPE_FILE,

--- a/test/libsqsh/file/file.c
+++ b/test/libsqsh/file/file.c
@@ -62,7 +62,7 @@ UTEST(file, load_file) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(0666, sqsh_file_permission(&file));
 	ASSERT_EQ((uint32_t)4242, sqsh_file_modified_time(&file));
 	ASSERT_EQ((uint32_t)1024, sqsh_file_blocks_start(&file));
@@ -107,11 +107,11 @@ UTEST(file, resolve_file) {
 
 	struct SqshFile *symlink = sqsh_lopen(&archive, "/src", &rv);
 	ASSERT_EQ(0, rv);
-	ASSERT_EQ(SQSH_FILE_TYPE_SYMLINK, sqsh_file_type(symlink));
+	ASSERT_EQ(SQSH_FILE_TYPE_SYMLINK, (int)sqsh_file_type(symlink));
 
 	rv = sqsh_file_symlink_resolve(symlink);
 	ASSERT_EQ(0, rv);
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(symlink));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(symlink));
 	ASSERT_EQ((uint32_t)3, sqsh_file_inode(symlink));
 
 	sqsh_close(symlink);
@@ -151,7 +151,7 @@ UTEST(file, resolve_unkown_dir_inode) {
 
 	struct SqshFile *symlink = sqsh_lopen(&archive, "/src", &rv);
 	ASSERT_EQ(0, rv);
-	ASSERT_EQ(SQSH_FILE_TYPE_SYMLINK, sqsh_file_type(symlink));
+	ASSERT_EQ(SQSH_FILE_TYPE_SYMLINK, (int)sqsh_file_type(symlink));
 	symlink->parent_inode_ref = UINT64_MAX;
 
 	rv = sqsh_file_symlink_resolve(symlink);

--- a/test/libsqsh/file/file_iterator.c
+++ b/test/libsqsh/file/file_iterator.c
@@ -65,7 +65,7 @@ UTEST(file_iterator, load_segment_from_compressed_data_block) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileIterator iter = {0};
@@ -122,7 +122,7 @@ UTEST(file_iterator, load_two_segments_from_uncompressed_data_block) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileIterator iter = {0};
@@ -207,7 +207,7 @@ UTEST(file_iterator, load_segment_from_uncompressed_data_block) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileIterator iter = {0};
@@ -262,7 +262,7 @@ UTEST(file_iterator, load_zero_padding) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileIterator iter = {0};
@@ -329,7 +329,7 @@ UTEST(file_iterator, load_zero_big_padding) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileIterator iter = {0};
@@ -395,7 +395,7 @@ UTEST(file_iterator, load_zero_block) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileIterator iter = {0};
@@ -441,7 +441,7 @@ UTEST(file_iterator, load_two_zero_blocks) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileIterator iter = {0};
@@ -496,7 +496,7 @@ UTEST(file_iterator, load_two_sparse_blocks) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileIterator iter = {0};
@@ -568,7 +568,7 @@ UTEST(file_iterator, open_directory_with_file_iterator) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_DIRECTORY, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_DIRECTORY, (int)sqsh_file_type(&file));
 
 	struct SqshFileIterator iter = {0};
 	rv = sqsh__file_iterator_init(&iter, &file);

--- a/test/libsqsh/file/file_reader.c
+++ b/test/libsqsh/file/file_reader.c
@@ -62,7 +62,7 @@ UTEST(file_reader, load_file_from_compressed_data_block) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileReader reader = {0};
@@ -107,7 +107,7 @@ UTEST(file_reader, load_file_from_compressed_data_block_with_offset) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileReader reader = {0};
@@ -149,7 +149,7 @@ UTEST(file_reader, load_file_from_uncompressed_data_block) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileReader reader = {0};
@@ -196,7 +196,7 @@ UTEST(file_reader, skip_over_zero_page) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_FILE, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_FILE, (int)sqsh_file_type(&file));
 	ASSERT_EQ(false, sqsh_file_has_fragment(&file));
 
 	struct SqshFileReader reader = {0};

--- a/test/libsqsh/xattr/xattr_iterator.c
+++ b/test/libsqsh/xattr/xattr_iterator.c
@@ -81,7 +81,7 @@ UTEST(xattr_iterator, load_xattr) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_DIRECTORY, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_DIRECTORY, (int)sqsh_file_type(&file));
 	ASSERT_EQ(true, sqsh_file_is_extended(&file));
 
 	struct SqshXattrIterator *iterator = sqsh_xattr_iterator_new(&file, &rv);
@@ -175,7 +175,7 @@ UTEST(xattr_iterator, load_xattr_indirect) {
 	rv = sqsh__file_init(&file, &archive, inode_ref);
 	ASSERT_EQ(0, rv);
 
-	ASSERT_EQ(SQSH_FILE_TYPE_DIRECTORY, sqsh_file_type(&file));
+	ASSERT_EQ(SQSH_FILE_TYPE_DIRECTORY, (int)sqsh_file_type(&file));
 	ASSERT_EQ(true, sqsh_file_is_extended(&file));
 
 	struct SqshXattrIterator *iterator = sqsh_xattr_iterator_new(&file, &rv);

--- a/tools/src/fs-common.c
+++ b/tools/src/fs-common.c
@@ -87,8 +87,6 @@ fs_common_mode_type(enum SqshFileType type) {
 		return S_IFIFO;
 	case SQSH_FILE_TYPE_SOCKET:
 		return S_IFSOCK;
-	case SQSH_FILE_TYPE_UNKNOWN:
-		return 0;
 	}
 	return 0;
 }

--- a/tools/src/ls.c
+++ b/tools/src/ls.c
@@ -111,9 +111,6 @@ print_detail(const char *path, const struct SqshTreeTraversal *traversal) {
 	}
 
 	switch (sqsh_file_type(file)) {
-	case SQSH_FILE_TYPE_UNKNOWN:
-		buffer[0] = '?';
-		break;
 	case SQSH_FILE_TYPE_DIRECTORY:
 		buffer[0] = 'd';
 		break;


### PR DESCRIPTION
This should never be returned. Rather than returning an unknown type, libsqsh does a consistency check and returns an error if the type is unknown.