### PR TITLE
Allow max_depth=0 for SqshTreeTraversal

### DIFF
--- a/libsqsh/src/tree/traversal.c
+++ b/libsqsh/src/tree/traversal.c
@@ -203,7 +203,8 @@ out:
 
 static bool
 init_next(struct SqshTreeTraversal *traversal) {
-	if (sqsh_file_type(traversal->base_file) == SQSH_FILE_TYPE_DIRECTORY) {
+	if (traversal->max_depth != 0 &&
+		sqsh_file_type(traversal->base_file) == SQSH_FILE_TYPE_DIRECTORY) {
 		traversal->state = SQSH_TREE_TRAVERSAL_STATE_DIRECTORY_BEGIN;
 	} else {
 		traversal->state = SQSH_TREE_TRAVERSAL_STATE_FILE;


### PR DESCRIPTION
It seems reasonable to extend the max_depth to do the reasonable thing when max_depth is 0 (yield only the root of the traversal, once)