### PR TITLE
Recycle stack items in SqshTreeTraversal on pop

### DIFF
--- a/libsqsh/include/sqsh_tree_private.h
+++ b/libsqsh/include/sqsh_tree_private.h
@@ -114,7 +114,6 @@ struct SqshTreeTraversal {
 
 	struct CxPreallocPool stack_pool;
 	struct SqshTreeTraversalStackElement *stack;
-	size_t stack_size;
 
 	size_t depth;
 	size_t max_depth;

--- a/libsqsh/src/tree/traversal.c
+++ b/libsqsh/src/tree/traversal.c
@@ -47,7 +47,6 @@ sqsh__tree_traversal_init(
 			&traversal->stack_pool, 8,
 			sizeof(struct SqshTreeTraversalStackElement));
 	traversal->stack = NULL;
-	traversal->stack_size = 0;
 	traversal->base_file = file;
 	traversal->state = SQSH_TREE_TRAVERSAL_STATE_INIT;
 	traversal->max_depth = SIZE_MAX;

--- a/libsqsh/src/tree/traversal.c
+++ b/libsqsh/src/tree/traversal.c
@@ -109,6 +109,7 @@ pop_stack(struct SqshTreeTraversal *traversal) {
 		sqsh__file_cleanup(&element->file);
 		sqsh__directory_iterator_cleanup(&element->iterator);
 		traversal->stack = element->next;
+		cx_prealloc_pool_recycle(&traversal->stack_pool, element);
 		element = traversal->stack;
 
 		if (traversal->stack == NULL) {


### PR DESCRIPTION
This allows re-using the stack items after popping.