### PR TITLE
unpack: use cextras for semaphore

### DIFF
--- a/subprojects/cextras.wrap
+++ b/subprojects/cextras.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = cextras
-revision = f3478d1e00d38846af03bd776d92336fbcf6e1f7
+revision = d063e11e5e3dd6fb1f9486f2ffa29c6b4e4a00be
 url = https://github.com/Gottox/cextras.git
 depth = 1
 

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -10,6 +10,11 @@ tool_sources = [
     'src/unpack.c',
 ]
 
+tool_dependencies = [
+    libsqsh_dep,
+    cextras_dep,
+]
+
 c_args = ['-DVERSION="@0@"'.format(meson.project_version())]
 
 tools = {}
@@ -21,7 +26,7 @@ foreach src : tool_sources
         c_args: c_args,
         include_directories: tools_private_include,
         install: not meson.is_subproject(),
-        dependencies: libsqsh_dep,
+        dependencies: tool_dependencies,
     )
     tools += {tool_name: tool}
 endforeach
@@ -33,7 +38,7 @@ if fuse3_dep.found()
         c_args: c_args,
         include_directories: tools_private_include,
         install: not meson.is_subproject(),
-        dependencies: [libsqsh_dep, fuse3_dep],
+        dependencies: tool_dependencies + [fuse3_dep],
     )
     tools += {'sqshfs': tool}
 endif
@@ -50,7 +55,7 @@ if fuse2_dep.found()
         c_args: c_args,
         include_directories: tools_private_include,
         install: not meson.is_subproject() and not fuse3_dep.found(),
-        dependencies: [libsqsh_dep, fuse2_dep],
+        dependencies: tool_dependencies + [fuse2_dep],
     )
     tools += {'sqshfs2': tool}
 endif


### PR DESCRIPTION
This replaces the use of semaphores with the cextras library. This allows support for platforms that do not provide sem_t semaphores such as OpenBSD or have deprecated them such as macOS.