### PR TITLE
file_iterator: implement a _copy() function

### DIFF
--- a/common/include/sqsh_reader_private.h
+++ b/common/include/sqsh_reader_private.h
@@ -143,6 +143,20 @@ SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__reader_init(
 /**
  * @internal
  * @memberof SqshReader
+ * @brief Creates a copy of an extractor reader.
+ *
+ * @param[out] target The reader to copy to.
+ * @param[in]  source The reader to copy from.
+ *
+ * @return 0 on success, a negative value on error.
+ */
+SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__reader_copy(
+		struct SqshReader *target, const struct SqshReader *source,
+		void *copied_iterator);
+
+/**
+ * @internal
+ * @memberof SqshReader
  * @brief Advances the reader by the given offset and size.
  *
  * @param[in,out] reader  Pointer to the metablock reader to be advanced.

--- a/common/src/reader/reader.c
+++ b/common/src/reader/reader.c
@@ -65,6 +65,49 @@ sqsh__reader_init(
 	return cx_buffer_init(&reader->buffer);
 }
 
+int
+sqsh__reader_copy(
+		struct SqshReader *target, const struct SqshReader *source,
+		void *copied_iterator) {
+	int rv = 0;
+
+	target->iterator = copied_iterator;
+	target->iterator_impl = source->iterator_impl;
+	target->iterator_offset = source->iterator_offset;
+	target->offset = source->offset;
+	const uint8_t *buffer_data = cx_buffer_data(&source->buffer);
+	const size_t buffer_size = cx_buffer_size(&source->buffer);
+	rv = cx_buffer_init(&target->buffer);
+	if (rv < 0) {
+		goto out;
+	}
+	rv = cx_buffer_append(
+			&target->buffer, cx_buffer_data(&source->buffer),
+			cx_buffer_size(&source->buffer));
+	if (rv < 0) {
+		goto out;
+	}
+	buffer_data = cx_buffer_data(&target->buffer);
+	const uint8_t *iterator_data = target->iterator_impl->data(copied_iterator);
+	const size_t iterator_size = target->iterator_impl->size(copied_iterator);
+	const uint8_t *data = source->data;
+
+	if (data == NULL) {
+		target->data = NULL;
+	} else if (data >= buffer_data && data < buffer_data + buffer_size) {
+		target->data = &buffer_data[data - buffer_data];
+	} else if (data >= iterator_data && data < iterator_data + iterator_size) {
+		target->data = &iterator_data[data - iterator_data];
+	} else {
+		rv = -SQSH_ERROR_INTERNAL;
+		goto out;
+	}
+	target->size = source->size;
+
+out:
+	return rv;
+}
+
 /**
  * @brief copies data from the iterator to the buffer until the buffer
  * reaches the desired size.

--- a/libsqsh/include/sqsh_extract_private.h
+++ b/libsqsh/include/sqsh_extract_private.h
@@ -213,7 +213,7 @@ SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__extract_manager_init(
  */
 SQSH_NO_EXPORT int sqsh__extract_manager_uncompress(
 		struct SqshExtractManager *manager, const struct SqshMapReader *reader,
-		const struct CxBuffer **target);
+		struct CxBuffer **target);
 
 /**
  * @internal
@@ -226,7 +226,7 @@ SQSH_NO_EXPORT int sqsh__extract_manager_uncompress(
  * @return 0 on success, a negative value on error.
  */
 SQSH_NO_EXPORT int sqsh__extract_manager_retain_buffer(
-		struct SqshExtractManager *manager, const struct CxBuffer *buffer);
+		struct SqshExtractManager *manager, struct CxBuffer *buffer);
 
 /**
  * @internal
@@ -265,7 +265,7 @@ struct SqshExtractView {
 	 * @privatesection
 	 */
 	struct SqshExtractManager *manager;
-	const struct CxBuffer *buffer;
+	struct CxBuffer *buffer;
 	uint64_t address;
 	size_t size;
 };

--- a/libsqsh/include/sqsh_extract_private.h
+++ b/libsqsh/include/sqsh_extract_private.h
@@ -176,10 +176,10 @@ struct SqshExtractManager {
 	/**
 	 * @privatesection
 	 */
-	struct CxRcRadixTree cache;
 	const struct SqshExtractorImpl *extractor_impl;
-	uint32_t block_size;
 	struct SqshMapManager *map_manager;
+	struct CxRcRadixTree cache;
+	uint32_t block_size;
 	struct CxLru lru;
 	sqsh__mutex_t lock;
 };
@@ -214,6 +214,19 @@ SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__extract_manager_init(
 SQSH_NO_EXPORT int sqsh__extract_manager_uncompress(
 		struct SqshExtractManager *manager, const struct SqshMapReader *reader,
 		const struct CxBuffer **target);
+
+/**
+ * @internal
+ * @memberof SqshExtractManager
+ * @brief Retains a buffer retrieved by sqsh__extract_manager_uncompress.
+ *
+ * @param[in]     manager     The manager to use.
+ * @param[out]    buffer      The buffer that needs to be retained
+ *
+ * @return 0 on success, a negative value on error.
+ */
+SQSH_NO_EXPORT int sqsh__extract_manager_retain_buffer(
+		struct SqshExtractManager *manager, const struct CxBuffer *buffer);
 
 /**
  * @internal
@@ -272,6 +285,18 @@ SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__extract_view_init(
 		struct SqshExtractView *view, struct SqshExtractManager *manager,
 		const struct SqshMapReader *reader);
 
+/**
+ * @internal
+ * @memberof SqshExtractView
+ * @brief Creates a copy of an extractor view.
+ *
+ * @param[out] target The view to copy to.
+ * @param[in]  source The view to copy from.
+ *
+ * @return 0 on success, a negative value on error.
+ */
+SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__extract_view_copy(
+		struct SqshExtractView *target, const struct SqshExtractView *source);
 /**
  * @internal
  * @memberof SqshExtractView

--- a/libsqsh/include/sqsh_file_private.h
+++ b/libsqsh/include/sqsh_file_private.h
@@ -168,6 +168,19 @@ SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__file_iterator_init(
 /**
  * @internal
  * @memberof SqshFileIterator
+ * @brief Creates a copy of a file iterator.
+ *
+ * @param[out] target The iterator to copy to.
+ * @param[in] source The iterator to copy from.
+ *
+ * @return 0 on success, less than 0 on error.
+ */
+SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__file_iterator_copy(
+		struct SqshFileIterator *target, const struct SqshFileIterator *source);
+
+/**
+ * @internal
+ * @memberof SqshFileIterator
  * @brief Cleans up resources used by a file iterator.
  *
  * @param[in] iterator The file iterator to clean up.

--- a/libsqsh/include/sqsh_file_private.h
+++ b/libsqsh/include/sqsh_file_private.h
@@ -84,6 +84,19 @@ SQSH_NO_EXPORT int sqsh__fragment_view_init(
 /**
  * @internal
  * @memberof SqshFragmentView
+ * @brief Creates a copy of an fragment view.
+ *
+ * @param[out] target The view to copy to.
+ * @param[in]  source The view to copy from.
+ *
+ * @return 0 on success, a negative value on error.
+ */
+SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__fragment_view_copy(
+		struct SqshFragmentView *target, const struct SqshFragmentView *source);
+
+/**
+ * @internal
+ * @memberof SqshFragmentView
  * @brief Retrieves the fragment data.
  *
  * @param[in] view The fragment view to retrieve the data from.
@@ -269,6 +282,9 @@ struct SqshFile {
  */
 SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__file_init(
 		struct SqshFile *context, struct SqshArchive *sqsh, uint64_t inode_ref);
+
+SQSH_NO_EXPORT SQSH_NO_UNUSED int
+sqsh__file_copy(struct SqshFile *context, const struct SqshFile *other);
 
 /**
  * @memberof SqshFile

--- a/libsqsh/include/sqsh_mapper_private.h
+++ b/libsqsh/include/sqsh_mapper_private.h
@@ -266,12 +266,12 @@ struct SqshMapIterator {
 	/**
 	 * @privatesection
 	 */
-	sqsh_index_t next_index;
-	uint64_t segment_count;
 	struct SqshMapManager *map_manager;
 	const struct SqshMapSlice *mapping;
 	const uint8_t *data;
 	size_t size;
+	sqsh_index_t next_index;
+	uint64_t segment_count;
 };
 
 /**
@@ -287,6 +287,19 @@ struct SqshMapIterator {
 SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__map_iterator_init(
 		struct SqshMapIterator *iterator, struct SqshMapManager *manager,
 		uint64_t address);
+
+/**
+ * @internal
+ * @memberof SqshMapIterator
+ * @brief Copies the content of a iterator to another iterator
+ *
+ * @param target The iterator to copy to
+ * @param source The iterator to copy from
+ *
+ * @return 0 on success, negative on error
+ */
+SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__map_iterator_copy(
+		struct SqshMapIterator *target, const struct SqshMapIterator *source);
 
 /**
  * @internal
@@ -393,6 +406,19 @@ struct SqshMapReader {
 SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__map_reader_init(
 		struct SqshMapReader *reader, struct SqshMapManager *mapper,
 		const uint64_t start_address, uint64_t upper_limit);
+
+/**
+ * @internal
+ * @memberof SqshMapReader
+ * @brief Copies the content of a reader to another reader
+ *
+ * @param target The reader to copy to
+ * @param source The reader to copy from
+ *
+ * @return 0 on success, negative on error
+ */
+SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__map_reader_copy(
+		struct SqshMapReader *target, const struct SqshMapReader *source);
 
 /**
  * @internal

--- a/libsqsh/include/sqsh_mapper_private.h
+++ b/libsqsh/include/sqsh_mapper_private.h
@@ -234,6 +234,18 @@ SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__map_manager_get(
 /**
  * @internal
  * @memberof SqshMapManager
+ * @brief Retains a slice for a chunk.
+ *
+ * @param[in] manager The SqshMapManager instance.
+ * @param[in] mapping The mapping to retain.
+ * @return Returns 0 on success, a negative value on error.
+ */
+SQSH_NO_EXPORT SQSH_NO_UNUSED int sqsh__map_manager_retain(
+		struct SqshMapManager *manager, const struct SqshMapSlice *mapping);
+
+/**
+ * @internal
+ * @memberof SqshMapManager
  * @brief Releases a map for a chunk.
  *
  * @param[in] manager The SqshMapManager instance.

--- a/libsqsh/src/extract/extract_manager.c
+++ b/libsqsh/src/extract/extract_manager.c
@@ -173,6 +173,13 @@ out:
 }
 
 int
+sqsh__extract_manager_retain_buffer(
+		struct SqshExtractManager *manager, const struct CxBuffer *buffer) {
+	cx_rc_radix_tree_retain_value(&manager->cache, (void *)buffer);
+	return 0;
+}
+
+int
 sqsh__extract_manager_release(
 		struct SqshExtractManager *manager, uint64_t address) {
 	int rv = sqsh__mutex_lock(&manager->lock);

--- a/libsqsh/src/extract/extract_manager.c
+++ b/libsqsh/src/extract/extract_manager.c
@@ -126,7 +126,7 @@ out:
 int
 sqsh__extract_manager_uncompress(
 		struct SqshExtractManager *manager, const struct SqshMapReader *reader,
-		const struct CxBuffer **target) {
+		struct CxBuffer **target) {
 	int rv = 0;
 	bool locked = false;
 	struct CxBuffer *buffer = NULL;
@@ -174,8 +174,8 @@ out:
 
 int
 sqsh__extract_manager_retain_buffer(
-		struct SqshExtractManager *manager, const struct CxBuffer *buffer) {
-	cx_rc_radix_tree_retain_value(&manager->cache, (void *)buffer);
+		struct SqshExtractManager *manager, struct CxBuffer *buffer) {
+	cx_rc_radix_tree_retain_value(&manager->cache, buffer);
 	return 0;
 }
 

--- a/libsqsh/src/extract/extract_view.c
+++ b/libsqsh/src/extract/extract_view.c
@@ -74,6 +74,7 @@ sqsh__extract_view_copy(
 	}
 	target->buffer = source->buffer;
 	target->size = source->size;
+	target->address = source->address;
 out:
 	if (rv < 0) {
 		sqsh__extract_view_cleanup(target);

--- a/libsqsh/src/extract/extract_view.c
+++ b/libsqsh/src/extract/extract_view.c
@@ -59,6 +59,28 @@ out:
 	return rv;
 }
 
+int
+sqsh__extract_view_copy(
+		struct SqshExtractView *target, const struct SqshExtractView *source) {
+	int rv = 0;
+
+	target->manager = source->manager;
+	if (source->buffer) {
+		rv = sqsh__extract_manager_retain_buffer(
+				source->manager, source->buffer);
+		if (rv < 0) {
+			goto out;
+		}
+	}
+	target->buffer = source->buffer;
+	target->size = source->size;
+out:
+	if (rv < 0) {
+		sqsh__extract_view_cleanup(target);
+	}
+	return rv;
+}
+
 const uint8_t *
 sqsh__extract_view_data(const struct SqshExtractView *view) {
 	return cx_buffer_data(view->buffer);

--- a/libsqsh/src/file/file_iterator.c
+++ b/libsqsh/src/file/file_iterator.c
@@ -90,6 +90,38 @@ out:
 	return rv;
 }
 
+int
+sqsh__file_iterator_copy(
+		struct SqshFileIterator *target,
+		const struct SqshFileIterator *source) {
+	int rv = 0;
+	target->file = source->file;
+	target->compression_manager = source->compression_manager;
+	rv = sqsh__map_reader_copy(&target->map_reader, &source->map_reader);
+	if (rv < 0) {
+		goto out;
+	}
+	rv = sqsh__extract_view_copy(&target->extract_view, &source->extract_view);
+	if (rv < 0) {
+		goto out;
+	}
+	rv = sqsh__fragment_view_copy(
+			&target->fragment_view, &source->fragment_view);
+	if (rv < 0) {
+		goto out;
+	}
+	target->sparse_size = source->sparse_size;
+	target->block_size = source->block_size;
+	target->block_index = source->block_index;
+	target->data = source->data;
+	target->size = source->size;
+out:
+	if (rv < 0) {
+		sqsh__file_iterator_cleanup(target);
+	}
+	return rv;
+}
+
 struct SqshFileIterator *
 sqsh_file_iterator_new(const struct SqshFile *file, int *err) {
 	SQSH_NEW_IMPL(sqsh__file_iterator_init, struct SqshFileIterator, file);

--- a/libsqsh/src/file/fragment_view.c
+++ b/libsqsh/src/file/fragment_view.c
@@ -163,6 +163,9 @@ sqsh__fragment_view_copy(
 		const struct SqshFragmentView *source) {
 	int rv = 0;
 	target->fragment_table = source->fragment_table;
+	if (target->fragment_table == NULL) {
+		goto out;
+	}
 	rv = sqsh__map_reader_copy(&target->map_reader, &source->map_reader);
 	if (rv < 0) {
 		goto out;

--- a/libsqsh/src/mapper/map_iterator.c
+++ b/libsqsh/src/mapper/map_iterator.c
@@ -73,8 +73,7 @@ sqsh__map_iterator_copy(
 		struct SqshMapIterator *target, const struct SqshMapIterator *source) {
 	int rv = 0;
 	target->map_manager = source->map_manager;
-	// TODO
-	// rv = sqsh__map_slice_copy(target->mapping, source->mapping);
+	rv = sqsh__map_manager_retain(target->map_manager, target->mapping);
 	if (rv < 0) {
 		goto out;
 	}

--- a/libsqsh/src/mapper/map_iterator.c
+++ b/libsqsh/src/mapper/map_iterator.c
@@ -69,6 +69,31 @@ sqsh__map_iterator_init(
 }
 
 int
+sqsh__map_iterator_copy(
+		struct SqshMapIterator *target, const struct SqshMapIterator *source) {
+	int rv = 0;
+	target->map_manager = source->map_manager;
+	// TODO
+	// rv = sqsh__map_slice_copy(target->mapping, source->mapping);
+	if (rv < 0) {
+		goto out;
+	}
+	target->mapping = NULL;
+	target->next_index = source->next_index;
+	target->segment_count = source->segment_count;
+	if (source->data != NULL) {
+		target->data = sqsh__map_slice_data(source->mapping);
+		target->size = sqsh__map_slice_size(source->mapping);
+	} else {
+		target->data = NULL;
+		target->size = 0;
+	}
+
+out:
+	return rv;
+}
+
+int
 sqsh__map_iterator_skip(struct SqshMapIterator *iterator, uint64_t *offset) {
 	int rv = 0;
 	uint64_t index;

--- a/libsqsh/src/mapper/map_manager.c
+++ b/libsqsh/src/mapper/map_manager.c
@@ -167,6 +167,24 @@ out:
 }
 
 int
+sqsh__map_manager_retain_slice(
+		struct SqshMapManager *manager, const struct SqshMapSlice *mapping) {
+	if (manager == NULL) {
+		return 0;
+	}
+	int rv = sqsh__mutex_lock(&manager->lock);
+	if (rv < 0) {
+		goto out;
+	}
+
+	cx_rc_radix_tree_retain_value(&manager->maps, mapping);
+
+	sqsh__mutex_unlock(&manager->lock);
+out:
+	return rv;
+}
+
+int
 sqsh__map_manager_release(
 		struct SqshMapManager *manager, const struct SqshMapSlice *mapping) {
 	if (manager == NULL || mapping == NULL) {

--- a/libsqsh/src/mapper/map_manager.c
+++ b/libsqsh/src/mapper/map_manager.c
@@ -167,9 +167,9 @@ out:
 }
 
 int
-sqsh__map_manager_retain_slice(
+sqsh__map_manager_retain(
 		struct SqshMapManager *manager, const struct SqshMapSlice *mapping) {
-	if (manager == NULL) {
+	if (manager == NULL || mapping == NULL) {
 		return 0;
 	}
 	int rv = sqsh__mutex_lock(&manager->lock);

--- a/libsqsh/src/mapper/map_reader.c
+++ b/libsqsh/src/mapper/map_reader.c
@@ -96,6 +96,27 @@ out:
 	return rv;
 }
 
+int
+sqsh__map_reader_copy(
+		struct SqshMapReader *target, const struct SqshMapReader *source) {
+	int rv;
+	rv = sqsh__map_iterator_copy(&target->iterator, &source->iterator);
+	if (rv < 0) {
+		goto out;
+	}
+	rv = sqsh__reader_copy(&target->reader, &source->reader, &target->iterator);
+	if (rv < 0) {
+		goto out;
+	}
+	target->address = source->address;
+	target->upper_limit = source->upper_limit;
+out:
+	if (rv < 0) {
+		sqsh__map_reader_cleanup(target);
+	}
+	return rv;
+}
+
 size_t
 sqsh__map_reader_remaining_direct(const struct SqshMapReader *reader) {
 	size_t block_size = sqsh__map_iterator_block_size(&reader->iterator);

--- a/subprojects/cextras.wrap
+++ b/subprojects/cextras.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = cextras
-revision = d063e11e5e3dd6fb1f9486f2ffa29c6b4e4a00be
+revision = c2d675dbd39f3f9b9d138907b965147819c17f6c
 url = https://github.com/Gottox/cextras.git
 depth = 1
 

--- a/test/libsqsh/extract/extract_manager.c
+++ b/test/libsqsh/extract/extract_manager.c
@@ -44,7 +44,7 @@ UTEST(directory_iterator, decompress) {
 	int rv;
 	struct SqshArchive archive = {0};
 	struct SqshExtractManager manager = {0};
-	const struct CxBuffer *buffer = NULL;
+	struct CxBuffer *buffer = NULL;
 	uint8_t payload[8192] = {SQSH_HEADER, ZLIB_ABCD};
 
 	mk_stub(&archive, payload, sizeof(payload));
@@ -78,8 +78,8 @@ UTEST(directory_iterator, decompress_and_cached) {
 	int rv;
 	struct SqshArchive archive = {0};
 	struct SqshExtractManager manager = {0};
-	const struct CxBuffer *buffer = NULL;
-	const struct CxBuffer *cached_buffer = NULL;
+	struct CxBuffer *buffer = NULL;
+	struct CxBuffer *cached_buffer = NULL;
 	uint8_t payload[8192] = {SQSH_HEADER, ZLIB_ABCD};
 
 	mk_stub(&archive, payload, sizeof(payload));


### PR DESCRIPTION
This function creates a copy of the iterator that has the same state as the original iterator.